### PR TITLE
fix: remove the default cpu and memory on deployment

### DIFF
--- a/application/values.yaml
+++ b/application/values.yaml
@@ -235,12 +235,13 @@ deployment:
     tcpSocket: {}
 
   # Resources to be defined for pod
-  resources:
-    limits:
-      memory: 256Mi
-    requests:
-      memory: 128Mi
-      cpu: 0.1
+  resources: {}
+#    limits:
+#      memory: 256Mi
+#      cpu: 0.5
+#    requests:
+#      memory: 128Mi
+#      cpu: 0.1
 
 #  Security Context at Container Level
   containerSecurityContext:

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -238,7 +238,6 @@ deployment:
   resources:
     limits:
       memory: 256Mi
-      cpu: 0.5
     requests:
       memory: 128Mi
       cpu: 0.1


### PR DESCRIPTION
- remove cpu limit on deployment
- remove delete the default cpu and memory on deployment
